### PR TITLE
Q2618138 Add GitHub Actions for release creation and CocoaPods publishing

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,57 @@
+name: Create Release
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read latest version from CHANGELOG.md
+        id: changelog
+        run: |
+          version=$(grep -m 1 -oP '^## \[\K[0-9]+\.[0-9]+\.[0-9]+' CHANGELOG.md)
+          if [ -z "$version" ]; then
+            echo "No version found in CHANGELOG.md"
+            exit 1
+          fi
+          echo "Latest version: $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Check if tag already exists
+        id: check_tag
+        run: |
+          if git rev-parse "refs/tags/${{ steps.changelog.outputs.version }}" >/dev/null 2>&1; then
+            echo "Tag ${{ steps.changelog.outputs.version }} already exists, skipping release."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Tag ${{ steps.changelog.outputs.version }} does not exist, proceeding with release."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Extract release notes from CHANGELOG.md
+        if: steps.check_tag.outputs.exists == 'false'
+        id: release_notes
+        run: |
+          version="${{ steps.changelog.outputs.version }}"
+          awk "/^## \[${version}\]/{found=1; next} /^## \[/{if(found) exit} found{print}" CHANGELOG.md > /tmp/release_notes.txt
+
+      - name: Create GitHub Release
+        if: steps.check_tag.outputs.exists == 'false'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.changelog.outputs.version }}
+          name: ${{ steps.changelog.outputs.version }}
+          body_path: /tmp/release_notes.txt
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -5,53 +5,29 @@ on:
     branches:
       - master
 
-permissions:
-  contents: write
-
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Read latest version from CHANGELOG.md
         id: changelog
         run: |
+          echo "Reading latest version from CHANGELOG.md..."
           version=$(grep -m 1 -oP '^## \[\K[0-9]+\.[0-9]+\.[0-9]+' CHANGELOG.md)
           if [ -z "$version" ]; then
-            echo "No version found in CHANGELOG.md"
+            echo "No version found in CHANGELOG.md!"
             exit 1
           fi
-          echo "Latest version: $version"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Latest version is $version"
+          echo "version=$version" >> $GITHUB_OUTPUT
 
-      - name: Check if tag already exists
-        id: check_tag
-        run: |
-          if git rev-parse "refs/tags/${{ steps.changelog.outputs.version }}" >/dev/null 2>&1; then
-            echo "Tag ${{ steps.changelog.outputs.version }} already exists, skipping release."
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Tag ${{ steps.changelog.outputs.version }} does not exist, proceeding with release."
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Extract release notes from CHANGELOG.md
-        if: steps.check_tag.outputs.exists == 'false'
-        id: release_notes
-        run: |
-          version="${{ steps.changelog.outputs.version }}"
-          awk "/^## \[${version}\]/{found=1; next} /^## \[/{if(found) exit} found{print}" CHANGELOG.md > /tmp/release_notes.txt
-
-      - name: Create GitHub Release
-        if: steps.check_tag.outputs.exists == 'false'
+      - name: Create release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.changelog.outputs.version }}
           name: ${{ steps.changelog.outputs.version }}
-          body_path: /tmp/release_notes.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_cocoapods.yml
+++ b/.github/workflows/publish_cocoapods.yml
@@ -1,0 +1,33 @@
+name: Publish to CocoaPods
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Validate podspec version matches release
+        run: |
+          podspec_version=$(grep -m1 "s.version" KlarnaMobileSDK.podspec | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          release_version="${{ github.event.release.tag_name }}"
+          if [ "$podspec_version" != "$release_version" ]; then
+            echo "ERROR: Podspec version ($podspec_version) does not match release version ($release_version)"
+            exit 1
+          fi
+          echo "Version match confirmed: $podspec_version"
+
+      - name: Lint podspec
+        run: pod spec lint KlarnaMobileSDK.podspec --allow-warnings
+
+      - name: Push to CocoaPods trunk
+        run: pod trunk push KlarnaMobileSDK.podspec --allow-warnings
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}

--- a/.github/workflows/publish_cocoapods.yml
+++ b/.github/workflows/publish_cocoapods.yml
@@ -14,6 +14,9 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name }}
 
+      - name: Install CocoaPods
+        run: gem install cocoapods -v 1.16.2
+
       - name: Validate podspec version matches release
         run: |
           podspec_version=$(grep -m1 "s.version" KlarnaMobileSDK.podspec | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
@@ -24,10 +27,12 @@ jobs:
           fi
           echo "Version match confirmed: $podspec_version"
 
-      - name: Lint podspec
-        run: pod spec lint KlarnaMobileSDK.podspec --allow-warnings
+      - name: Verify pod trunk authentication
+        run: pod trunk me
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
 
       - name: Push to CocoaPods trunk
-        run: pod trunk push KlarnaMobileSDK.podspec --allow-warnings
+        run: pod trunk push KlarnaMobileSDK.podspec
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}

--- a/.github/workflows/publish_spm.yml
+++ b/.github/workflows/publish_spm.yml
@@ -40,7 +40,9 @@ jobs:
           git config user.name "Klarna Mobile SDK"
           git config user.email "67329369+klarna-msdk@users.noreply.github.com"
           git commit -m "update package v${version}"
-          git push origin main
+          git push -u https://${GH_TOKEN}@github.com/klarna/klarna-mobile-sdk-spm.git main
+        env:
+          GH_TOKEN: ${{ secrets.SPM_REPO_TOKEN }}
 
       - name: Create release in SPM repository
         if: steps.diff.outputs.changed == 'true'

--- a/.github/workflows/publish_spm.yml
+++ b/.github/workflows/publish_spm.yml
@@ -1,0 +1,49 @@
+name: Publish SPM Package
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout SPM repository
+        uses: actions/checkout@v4
+        with:
+          repository: klarna/klarna-mobile-sdk-spm
+          token: ${{ secrets.SPM_REPO_TOKEN }}
+
+      - name: Fetch Package.swift from main repository
+        run: |
+          curl -fSL https://raw.githubusercontent.com/klarna/klarna-mobile-sdk-ios/refs/heads/master/Package.swift -o Package.swift
+          cat Package.swift
+
+      - name: Check for changes
+        id: diff
+        run: |
+          git add Package.swift
+          if git diff --staged --quiet; then
+            echo "Package.swift is already up to date — skipping."
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "Package.swift has changes."
+            git diff --staged
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit and push
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          version="${{ github.event.release.tag_name }}"
+          git config user.name "Klarna Mobile SDK"
+          git config user.email "67329369+klarna-msdk@users.noreply.github.com"
+          git commit -m "update package v${version}"
+          git push origin main
+
+      - name: Create release in SPM repository
+        if: steps.diff.outputs.changed == 'true'
+        run: gh release create "${{ github.event.release.tag_name }}" --title "${{ github.event.release.tag_name }}" --target main
+        env:
+          GH_TOKEN: ${{ secrets.SPM_REPO_TOKEN }}

--- a/.github/workflows/publish_spm.yml
+++ b/.github/workflows/publish_spm.yml
@@ -46,6 +46,6 @@ jobs:
 
       - name: Create release in SPM repository
         if: steps.diff.outputs.changed == 'true'
-        run: gh release create "${{ github.event.release.tag_name }}" --title "${{ github.event.release.tag_name }}" --target main
+        run: gh release create "${{ github.event.release.tag_name }}" --title "${{ github.event.release.tag_name }}" --target main --repo "github.com/klarna/klarna-mobile-sdk-spm"
         env:
           GH_TOKEN: ${{ secrets.SPM_REPO_TOKEN }}


### PR DESCRIPTION
### Summary:                                                  
  - Add create_release.yml workflow that triggers on push to master, reads the version from CHANGELOG.md, and creates a GitHub Release (matching the Android SDK's workflow pattern)                              
  - Add publish_cocoapods.yml workflow that triggers on release published, validates podspec version matches the release tag, then runs pod trunk push with pinned CocoaPods v1.16.2 (matching KEP pipeline
  behavior)                                                                                                                                                                                                       
  - SPM publishing requires no separate workflow — the git tag created by the release workflow is sufficient since Package.swift already uses CDN-hosted binary targets. klarna-mobile-sdk-spm repo can be
  deprecated.  
                                                                                                                                                                                                                  
 ### Test plan:                                                                                                                                                                                                      
  - Add COCOAPODS_TRUNK_TOKEN as a repository secret                                                                                                                                                              
  - Merge to master and verify create_release.yml runs (release already exists for 2.11.1, action updates it harmlessly)
  - On next release: verify GitHub Release is created with correct tag                                                                                                                                            
  - Verify publish_cocoapods.yml triggers and publishes the pod successfully
