### PR TITLE
Fix create_release action not trigger another actions

### DIFF
--- a/.github/workflows/publish_cocoapods.yml
+++ b/.github/workflows/publish_cocoapods.yml
@@ -1,18 +1,33 @@
 name: Publish to CocoaPods
 
 on:
-  release:
+  workflow_run:
+    workflows: ["Create Release"]
     types:
-      - published
+      - completed
+  workflow_dispatch:
 
 jobs:
   publish:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: macos-latest
     steps:
+      - name: Get latest release version
+        id: release
+        run: |
+          version=$(gh release list --repo "${{ github.repository }}" --limit 1 --json tagName --jq '.[0].tagName')
+          if [ -z "$version" ]; then
+            echo "ERROR: No release found!"
+            exit 1
+          fi
+          echo "version=$version" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ steps.release.outputs.version }}
 
       - name: Install CocoaPods
         run: gem install cocoapods -v 1.16.2
@@ -20,7 +35,7 @@ jobs:
       - name: Validate podspec version matches release
         run: |
           podspec_version=$(grep -m1 "s.version" KlarnaMobileSDK.podspec | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-          release_version="${{ github.event.release.tag_name }}"
+          release_version="${{ steps.release.outputs.version }}"
           if [ "$podspec_version" != "$release_version" ]; then
             echo "ERROR: Podspec version ($podspec_version) does not match release version ($release_version)"
             exit 1

--- a/.github/workflows/publish_spm.yml
+++ b/.github/workflows/publish_spm.yml
@@ -1,14 +1,29 @@
 name: Publish SPM Package
 
 on:
-  release:
+  workflow_run:
+    workflows: ["Create Release"]
     types:
-      - published
+      - completed
+  workflow_dispatch:
 
 jobs:
   publish:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
+      - name: Get latest release version
+        id: release
+        run: |
+          version=$(gh release list --repo "${{ github.repository }}" --limit 1 --json tagName --jq '.[0].tagName')
+          if [ -z "$version" ]; then
+            echo "ERROR: No release found!"
+            exit 1
+          fi
+          echo "version=$version" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout SPM repository
         uses: actions/checkout@v4
         with:
@@ -36,7 +51,7 @@ jobs:
       - name: Commit and push
         if: steps.diff.outputs.changed == 'true'
         run: |
-          version="${{ github.event.release.tag_name }}"
+          version="${{ steps.release.outputs.version }}"
           git config user.name "Klarna Mobile SDK"
           git config user.email "67329369+klarna-msdk@users.noreply.github.com"
           git commit -m "update package v${version}"
@@ -46,6 +61,6 @@ jobs:
 
       - name: Create release in SPM repository
         if: steps.diff.outputs.changed == 'true'
-        run: gh release create "${{ github.event.release.tag_name }}" --title "${{ github.event.release.tag_name }}" --target main --repo "github.com/klarna/klarna-mobile-sdk-spm"
+        run: gh release create "${{ steps.release.outputs.version }}" --title "${{ steps.release.outputs.version }}" --target main --repo "klarna/klarna-mobile-sdk-spm"
         env:
           GH_TOKEN: ${{ secrets.SPM_REPO_TOKEN }}


### PR DESCRIPTION
## Problem

The `publish_cocoapods.yml` and `publish_spm.yml` workflows trigger on `release: published`, but the release is created by `create_release.yml` using the default `GITHUB_TOKEN`. When you use `GITHUB_TOKEN` to perform tasks, events triggered by it [will not create new workflow runs](https://docs.github.com/en/actions/concepts/security/github_token#when-github_token-triggers-workflow-runs) to prevent recursive runs. This means the `release: published` event is never emitted, so CocoaPods and SPM publishing never triggers automatically.

## Solution

Replace `on: release: types: [published]` with `on: workflow_run` listening on the "Create Release" workflow. The `release: published` event is suppressed, but the "Create Release" workflow itself still runs and completes normally. Since `workflow_run` watches **workflow lifecycle** (not repository events), it triggers reliably regardless of the `GITHUB_TOKEN` limitation.

## Changes

- Both workflows now trigger via `workflow_run` after "Create Release" completes successfully
- Added `workflow_dispatch` as a manual fallback for re-runs
- Release version is fetched via `gh release list` instead of `github.event.release.tag_name` (not available in `workflow_run` context)
- Guard condition ensures publish only runs on successful release creation
- `create_release.yml` is **unchanged** — no coupling introduced; downstream workflows listen to upstream, same pattern as before